### PR TITLE
Simple Redirect Feature

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,7 +139,7 @@ jobs:
       - run:
           name: run acceptance tests
           working_directory: ~/repo/http_server_spec
-          command: bundle exec spinach --tags @simple-get,@simple-head,@simple-options
+          command: bundle exec spinach --tags @simple-get,@simple-head,@simple-options,@simple-redirect
 
       - run:
           name: sleep 12

--- a/src/main/kotlin/HttpStatus.kt
+++ b/src/main/kotlin/HttpStatus.kt
@@ -1,0 +1,13 @@
+package httpstatus
+
+enum class HttpStatus(val value: Int) {
+    OK(200), BadRequest(400), NotFound(404), MovedPermanently(301), InternalServerError(500);
+    val message: String
+        get() = when(this) {
+            OK -> "OK"
+            BadRequest -> "Bad Request"
+            NotFound -> "Not Found"
+            MovedPermanently -> "Moved Permanently"
+            InternalServerError -> "Internal Server Error"
+        }
+}

--- a/src/main/kotlin/ResponseBuilder.kt
+++ b/src/main/kotlin/ResponseBuilder.kt
@@ -1,38 +1,30 @@
 package response
+import httpstatus.HttpStatus
 
-class ResponseBuilder(private val statusCode: Int,
+class ResponseBuilder(private val statusCode: HttpStatus,
                       private val body: String = "",
-                      private val headers: Map<String, List<String>> = mapOf()
+                      private val headers: Map<String, String> = mapOf()
                       ) {
     private val protocol = "HTTP/1.1"
     private val crlf = "\r\n"
 
     fun build(): String {
         val statusLine = generateStatusLine()
-        var responseHeaders = generateHeaders()
-        var responseBody = if (body.isNotEmpty()) setContentLength() + "$crlf$body" else ""
+        val responseHeaders = generateHeaders()
+        val responseBody = if (body.isNotEmpty()) setContentLength() + "$crlf$body" else ""
         return statusLine + responseHeaders + responseBody
     }
 
     private fun generateStatusLine(): String {
-        val statusMessage = findStatusMessage()
-        return "$protocol $statusCode $statusMessage$crlf"
+        return "$protocol ${statusCode.value} ${statusCode.message}$crlf"
     }
-
-    private fun findStatusMessage(): String =
-        when(statusCode) {
-            200 -> "OK"
-            400 -> "Bad Request"
-            404 -> "Not Found"
-            else -> "500"
-        }
 
     private fun setContentLength() = "Content-Length: ${body.length}$crlf"
 
     private fun generateHeaders(): String {
         var httpHeaders = ""
         for (header in headers) {
-            httpHeaders += "${header.key}: ${header.value.joinToString()}$crlf"
+            httpHeaders += "${header.key}: ${header.value}$crlf"
         }
         return httpHeaders
     }

--- a/src/main/kotlin/controllers/BadRequestController.kt
+++ b/src/main/kotlin/controllers/BadRequestController.kt
@@ -1,8 +1,9 @@
 package controllers
 import response.ResponseBuilder
+import httpstatus.HttpStatus
 
 class BadRequestController : Controller {
-    private val statusCode = 400
+    private val statusCode = HttpStatus.BadRequest
 
     override fun action(): ResponseBuilder {
         return ResponseBuilder(statusCode)

--- a/src/main/kotlin/controllers/MethodOptions2Controller.kt
+++ b/src/main/kotlin/controllers/MethodOptions2Controller.kt
@@ -1,10 +1,10 @@
 package controllers
-
 import response.ResponseBuilder
+import httpstatus.HttpStatus
 
 class MethodOptions2Controller : Controller {
-    private val statusCode = 200
-    private val headers: Map<String, List<String>> = mapOf("Allow" to listOf("GET", "HEAD", "OPTIONS", "PUT", "POST"))
+    private val statusCode = HttpStatus.OK
+    private val headers: Map<String, String> = mapOf("Allow" to "GET, HEAD, OPTIONS, PUT, POST")
 
     override fun action(): ResponseBuilder {
         return ResponseBuilder(statusCode, headers = headers)

--- a/src/main/kotlin/controllers/MethodOptionsController.kt
+++ b/src/main/kotlin/controllers/MethodOptionsController.kt
@@ -1,9 +1,10 @@
 package controllers
 import response.ResponseBuilder
+import httpstatus.HttpStatus
 
 class MethodOptionsController : Controller {
-    private val statusCode = 200
-    private val headers: Map<String, List<String>> = mapOf("Allow" to listOf("GET", "HEAD", "OPTIONS"))
+    private val statusCode = HttpStatus.OK
+    private val headers: Map<String, String> = mapOf("Allow" to "GET, HEAD, OPTIONS")
 
     override fun action(): ResponseBuilder {
         return ResponseBuilder(statusCode, headers = headers)

--- a/src/main/kotlin/controllers/NotFoundController.kt
+++ b/src/main/kotlin/controllers/NotFoundController.kt
@@ -1,8 +1,9 @@
 package controllers
 import response.ResponseBuilder
+import httpstatus.HttpStatus
 
 class NotFoundController : Controller {
-    val statusCode = 404
+    val statusCode = HttpStatus.NotFound
 
     override fun action(): ResponseBuilder {
         return ResponseBuilder(statusCode)

--- a/src/main/kotlin/controllers/RedirectController.kt
+++ b/src/main/kotlin/controllers/RedirectController.kt
@@ -1,0 +1,13 @@
+package controllers
+
+import response.ResponseBuilder
+import httpstatus.HttpStatus
+
+class RedirectController : Controller {
+    private val statusCode = HttpStatus.MovedPermanently
+    private val headers: Map<String, String> = mapOf("Location" to "http://127.0.0.1:5000/simple_get")
+
+    override fun action(): ResponseBuilder {
+        return ResponseBuilder(statusCode, headers = headers)
+    }
+}

--- a/src/main/kotlin/controllers/SimpleGetController.kt
+++ b/src/main/kotlin/controllers/SimpleGetController.kt
@@ -1,8 +1,9 @@
 package controllers
 import response.ResponseBuilder
+import httpstatus.HttpStatus
 
 class SimpleGetController : Controller {
-    private val statusCode = 200
+    private val statusCode = HttpStatus.OK
 
     override fun action(): ResponseBuilder {
         return ResponseBuilder(statusCode)

--- a/src/main/kotlin/controllers/SimpleGetWithBodyController.kt
+++ b/src/main/kotlin/controllers/SimpleGetWithBodyController.kt
@@ -1,8 +1,9 @@
 package controllers
 import response.ResponseBuilder
+import httpstatus.HttpStatus
 
 class SimpleGetWithBodyController : Controller {
-    private val statusCode = 200
+    private val statusCode = HttpStatus.OK
     private val body = "Hello world"
 
     override fun action(): ResponseBuilder {

--- a/src/main/kotlin/main.kt
+++ b/src/main/kotlin/main.kt
@@ -18,6 +18,7 @@ fun main() {
     router.addRoute("HEAD", "/head_request", SimpleGetController())
     router.addRoute("OPTIONS", "/method_options", MethodOptionsController())
     router.addRoute("OPTIONS", "/method_options2", MethodOptions2Controller())
+    router.addRoute("GET", "/redirect", RedirectController())
 
     println("Server is running on port ${serverSocket.localPort}")
     Server(serverSocket, parser, router).start()

--- a/src/test/kotlin/ResponseBuilderTest.kt
+++ b/src/test/kotlin/ResponseBuilderTest.kt
@@ -1,34 +1,43 @@
 import kotlin.test.*
 import response.ResponseBuilder
+import httpstatus.HttpStatus
 
 class ResponseBuilderTest {
     @Test
     fun `given a simple_get request build a response`() {
-        val responseBuilder = ResponseBuilder(200)
+        val responseBuilder = ResponseBuilder(HttpStatus.OK)
         val expectation = "HTTP/1.1 200 OK\r\n"
         assertEquals(expectation, responseBuilder.build())
     }
 
     @Test
     fun `given a simple_get_with_body request build a response`() {
-        val responseBuilder = ResponseBuilder(200, "Hello world")
+        val responseBuilder = ResponseBuilder(HttpStatus.OK, "Hello world")
         val expectation = "HTTP/1.1 200 OK\r\nContent-Length: 11\r\n\r\nHello world"
         assertEquals(expectation, responseBuilder.build())
     }
 
     @Test
     fun `given method_options build response`() {
-        val headers: Map<String, List<String>> = mapOf("Allow" to listOf("GET", "HEAD", "OPTIONS"))
-        val responseBuilder = ResponseBuilder(200, headers = headers)
+        val headers: Map<String, String> = mapOf("Allow" to "GET, HEAD, OPTIONS")
+        val responseBuilder = ResponseBuilder(HttpStatus.OK, headers = headers)
         val expectation = "HTTP/1.1 200 OK\r\nAllow: GET, HEAD, OPTIONS\r\n"
         assertEquals(expectation, responseBuilder.build())
     }
 
     @Test
     fun `given method_options2 build response`() {
-        val headers: Map<String, List<String>> = mapOf("Allow" to listOf("GET", "HEAD", "OPTIONS", "PUT", "POST"))
-        val responseBuilder = ResponseBuilder(200, headers = headers)
+        val headers: Map<String, String> = mapOf("Allow" to "GET, HEAD, OPTIONS, PUT, POST")
+        val responseBuilder = ResponseBuilder(HttpStatus.OK, headers = headers)
         val expectation = "HTTP/1.1 200 OK\r\nAllow: GET, HEAD, OPTIONS, PUT, POST\r\n"
+        assertEquals(expectation, responseBuilder.build())
+    }
+
+    @Test
+    fun `given redirect build response`() {
+        val headers: Map<String, String> = mapOf("Location" to "http://127.0.0.1:5000/simple_get")
+        val responseBuilder = ResponseBuilder(HttpStatus.MovedPermanently, headers = headers)
+        val expectation = "HTTP/1.1 301 Moved Permanently\r\nLocation: http://127.0.0.1:5000/simple_get\r\n"
         assertEquals(expectation, responseBuilder.build())
     }
 }

--- a/src/test/kotlin/RouterTest.kt
+++ b/src/test/kotlin/RouterTest.kt
@@ -3,9 +3,14 @@ import router.Router
 import kotlin.test.*
 
 class RouterTest {
-    private val badRequestController = BadRequestController()
-    private val notFoundController = NotFoundController()
-    private val router = Router(badRequestController, notFoundController)
+    private lateinit var router: Router
+
+    @BeforeTest
+    fun init() {
+        val badRequestController = BadRequestController()
+        val notFoundController = NotFoundController()
+        router = Router(badRequestController, notFoundController)
+    }
 
     @Test
     fun `expect addRoute member to add GET method to the simple_get route`() {
@@ -92,6 +97,21 @@ class RouterTest {
         router.addRoute("OPTIONS", "/method_options2", MethodOptions2Controller())
         val controller = router.getController("OPTIONS", "/method_options2")
         assertIs<MethodOptions2Controller>(controller)
+    }
+
+    @Test
+    fun `expect addRoute member to add GET method to redirect route`() {
+        val redirectController = RedirectController()
+        router.addRoute("GET", "/redirect", redirectController)
+        val expectation: MutableMap<String, MutableMap<String, Controller>> = mutableMapOf("/redirect" to mutableMapOf("GET" to redirectController))
+        assertEquals(expectation, router.routes)
+    }
+
+    @Test
+    fun `expect getController to return controller from redirect route when http method is GET`() {
+        router.addRoute("GET", "/redirect", RedirectController())
+        val controller = router.getController("GET", "/redirect")
+        assertIs<RedirectController>(controller)
     }
 
 }


### PR DESCRIPTION
[Link to story](https://trello.com/c/7oe7RNiQ/69-kotlin-server-simple-redirect-feature-2)

Description:

- Created a `RedirectController` for handling `/redirect` request, and tested through `RouterTest` and `ResponseBuilderTest`
- Created an `enum` class for HTTP status codes and messages, called `HTTPStatus`
- Replaced direct declaration of status codes in controllers with `HTTPStatus` names
- `statusCode` property in `ResponseBuilder` is no longer an `Int`, but an `HTTPStatus`
- Removed the `findStatusMessage` method from `ResponseBuilder` since `HTTPStatus` property `message` has a getter accessor for returning the correct message based on the `HTTPStatus` name passed to the `ResponseBuilder`
- Updated all controllers to utilize `HTTPStatus`
- `headers` property in `ResponseBuilder` is no longer a `Map<String, List<String>>`. I've changed it to `Map<String, String>`. `List<String>` was unnecessary since it did not accomplish anything that couldn't be done with a `String`