### PR TITLE
resolved connection reset and IndexOutOfBounds error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ gradle-app.setting
 # IDE
 .idea/
 *.iml
+
+*.DS_Store

--- a/src/main/kotlin/Server.kt
+++ b/src/main/kotlin/Server.kt
@@ -1,6 +1,7 @@
 import router.Router
 import request.RequestParser
 import java.io.BufferedReader
+import java.io.InputStream
 import java.io.InputStreamReader
 import java.io.PrintWriter
 import java.net.ServerSocket
@@ -35,17 +36,14 @@ class Server(private val serverSocket: ServerSocket,
         }
     }
 
-    fun acceptConnection() {
+    private fun acceptConnection() {
         socket = serverSocket.accept()
-        val inputStream = socket.getInputStream()
-        while (inputStream.available() == 0) {
-            continue
-        }
+        val inputStream = populateInputStream(socket)
         reader = BufferedReader(InputStreamReader(inputStream))
         writer = PrintWriter(socket.getOutputStream(), true)
     }
 
-    fun readRequest(): String {
+    private fun readRequest(): String {
         var clientRequest = ""
 
         while (reader.ready()) {
@@ -54,13 +52,21 @@ class Server(private val serverSocket: ServerSocket,
         return clientRequest
     }
 
-    fun writeResponse(response: String) {
+    private fun writeResponse(response: String) {
         writer.println(response)
     }
 
-    fun closeConnection() {
+    private fun closeConnection() {
         reader.close()
         writer.close()
         socket.close()
+    }
+
+    private fun populateInputStream(socket: Socket): InputStream {
+        val stream = socket.getInputStream()
+        while(stream.available() == 0) {
+            continue
+        }
+        return stream
     }
 }

--- a/src/main/kotlin/Server.kt
+++ b/src/main/kotlin/Server.kt
@@ -37,7 +37,11 @@ class Server(private val serverSocket: ServerSocket,
 
     fun acceptConnection() {
         socket = serverSocket.accept()
-        reader = BufferedReader(InputStreamReader(socket.getInputStream()))
+        val inputStream = socket.getInputStream()
+        while (inputStream.available() == 0) {
+            continue
+        }
+        reader = BufferedReader(InputStreamReader(inputStream))
         writer = PrintWriter(socket.getOutputStream(), true)
     }
 


### PR DESCRIPTION
[Link to story](https://trello.com/c/SmkOJmJk/85-spike-story-connection-reset-by-peer2)

Errors:

- Server-side: `IndexOutOfBounds` exception
- Client-side: `error reading from socket: Connection reset by peer`

What caused the Server error?
	- The `InputStream` seems to be empty, so when the Server reads from it, it produces an empty `List`, which when trying to access an element in the `RequestParser`'s `parse` method results in an `IndexOutOfBoundsException`
What caused the Client error?
	- Client sends a request, but found that logging`socket.getInputStream().available())` after `acceptConnection` inside the `Server`'s `start()` method logs 0, which means that there are no bytes to read from the InputStream .
	- The connection is accepted, so the Server continues the flow of execution. Continuing the flow of execution results in catching an `IndexOutOfBoundException`, and then executes the `finally` block which closes the connection. So the client never received a response but noticed the Server abruptly closed the connection, which led to the `error reading from socket: Connection reset by peer`

Solution:

- The `Server` receives the request, but there seems to be a discrepancy between the `BufferedReader` being `ready()` and the `InputStream` actually being filled with request data. 
- The solution is to stall the execution of the program until there is actually some data in the `InputStream`. Please see the solution below. The solution seems a bit hacky. Please let me know what your thoughts are and I'd appreciate any feedback!